### PR TITLE
fix: compatibility with mongodb 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "parse-duration": "^1.0.0"
   },
   "peerDependencies": {
-    "mongodb": ">=4 <5"
+    "mongodb": ">=5.7.0 <7"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -208,6 +208,7 @@ async function findATaskToRun(enforcedTask: EnforcedTask | null): Promise<Task |
                 'runLog.0.finishedAt': 1, // prefer tasks waiting longer
             },
             projection: { _id: true, runImmediately: true },
+            includeResultMetadata: true
         },
     );
 


### PR DESCRIPTION
`includeResultMetadata` (defaulting to true) has been added to "findOneAndXXX" methods in mongodb 5.7.0 : https://github.com/mongodb/node-mongodb-native/releases/tag/v5.7.0

In mongodb 6.0, it is now defaulting to false, and breaks mongodash :
https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0

A very simple change makes it work.