### PR TITLE
refactor(cron,runner,metrics): unify cron runners + follower metrics fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,17 +26,19 @@ during iteration.
 Two task subsystems, both share `ConcurrentRunner` as the worker pool:
 
 - **Cron tasks** (`src/cronTasks.ts`) — scheduled jobs keyed by `taskId`.
-  - Default path: single-loop `runATask` (concurrency=1, BC).
-  - Opt-in parallel path: `cronTaskConcurrency > 1` uses `ConcurrentRunner`.
-  - Unifying serial/parallel is **now possible** but still nontrivial: the
-    serial path is the BC baseline and specific race regressions
-    (pendingWake, runnerStopPromise, finish-mid-prolong, revert-on-cancel)
-    are pinned in `test/cronTasks.races.regression.ts`. Any refactor must
-    keep those green; behaviour tests in `test/cronTasks.behavior.ts` are
-    run-time tolerant and won't block a structural change.
-  - `pendingWake` flag handles the race where a task is registered mid-loop.
+  - Single scheduler: `ConcurrentRunner` for all concurrencies. The
+    default `cronTaskConcurrency=1` spawns one worker; higher values
+    spawn more. Per-task serialisation is enforced via the DB
+    `lockedTill` lock, so concurrency never causes a single task to
+    double-run.
   - `runnerStopPromise` prevents rapid stop+start from leaving the runner
-    wedged (runnerStarted=true but no live workers).
+    wedged (runnerStarted=true but no live workers). ensureStarted chains
+    on a pending stop before firing a new start.
+  - `ConcurrentRunner.start()` resets each source's nextRunAt +
+    currentBackoff, and `setNextRunAt()` no-ops if nextRunAt is already
+    <= now (preserves a concurrent speedUp). `runATask` therefore
+    does not need caller-side race workarounds; see the
+    "refactor(concurrent-runner): close three scheduler races" commit.
 
 - **Reactive tasks** (`src/reactiveTasks/`) — change-stream driven.
   - `LeaderElector` → `Planner` (change stream + batching + reconciliation)
@@ -50,10 +52,15 @@ Two task subsystems, both share `ConcurrentRunner` as the worker pool:
    `() => void` is expected. The internal parallel-runner stop is
    fire-and-forget via `runnerStopPromise`.
 
-2. **Serial cron's `runATask` mutates `state.working` + `state.pendingWake`.**
-   When registering mid-iteration, `ensureStarted` sets `pendingWake=true`
-   instead of calling `runATask` directly (which would create a second
-   concurrent loop). The finally block checks this flag.
+2. **`ConcurrentRunner.setNextRunAt()` never pushes an already-due
+   source back into the future.** If `state.nextRunAt` is already
+   `<= now`, the write is skipped. A worker that finishes a poll and
+   calls `setNextRunAt(now + waitMs)` based on a stale query must not
+   overwrite a concurrent `speedUp()` that happened during the query.
+   Combined with the `resolved`-guarded re-check at the top of
+   `sleep()` and the source reset in `start()`, the runner absorbs the
+   three races that previously forced caller workarounds (cron used
+   two, see the "close three scheduler races" commit).
 
 3. **`createContinuousLock` CAS mode** uses `expectedInitialValue` +
    `onLockLost`. Worker passes `taskRecord.nextRunAt`; CAS detects

--- a/src/ConcurrentRunner.ts
+++ b/src/ConcurrentRunner.ts
@@ -66,6 +66,18 @@ export class ConcurrentRunner {
         this.isRunning = true;
         this.tryRunATask = tryRunATask;
 
+        // Source metadata is intentionally preserved across stop() (callers
+        // may re-use the same runner instance), but a stale nextRunAt from
+        // a previous cycle would otherwise make freshly spawned workers
+        // sleep for the remainder of that (possibly hour-long) window
+        // before noticing new work. Reset schedules so a fresh start polls
+        // immediately.
+        const now = Date.now();
+        for (const state of this.sources.values()) {
+            state.nextRunAt = now;
+            state.currentBackoff = state.options.minPollMs;
+        }
+
         for (let i = 0; i < this.options.concurrency; i++) {
             this.workers.push(this.runWorker());
         }
@@ -99,10 +111,12 @@ export class ConcurrentRunner {
      * is due - e.g. cron scheduling an hour out - to skip wasted polls.
      *
      * - `runAt` must be a finite number; non-finite values are ignored.
-     * - The timestamp is *not* clamped relative to `now`. Passing a value in
-     *   the past is valid and behaves like {@link speedUp}; passing a value
-     *   far in the future means the source will not be polled until then
-     *   (or until `speedUp` / `setNextRunAt` is called again).
+     * - If `state.nextRunAt` is already at or before `now`, the write is
+     *   skipped: something more urgent (usually {@link speedUp}) has
+     *   already signalled an immediate poll and we must not push it
+     *   back out. The worker picks up the signal on its next iteration.
+     * - Otherwise `nextRunAt` is overwritten with `runAt` (even if `runAt`
+     *   is in the past - that behaves like {@link speedUp}).
      * - Back-off is reset so a subsequent wake-up fires at `minPollMs`.
      */
     public setNextRunAt(sourceName: string, runAt: number): void {
@@ -110,7 +124,9 @@ export class ConcurrentRunner {
         if (!state) return;
         if (!Number.isFinite(runAt)) return;
         state.currentBackoff = state.options.minPollMs;
-        state.nextRunAt = runAt;
+        if (state.nextRunAt > Date.now()) {
+            state.nextRunAt = runAt;
+        }
         // Wake workers so any currently-sleeping one can recompute its wait.
         this.wakeUpAllWorkers();
     }
@@ -187,10 +203,12 @@ export class ConcurrentRunner {
         return new Promise<void>((resolve) => {
             if (ms <= 0) return resolve();
 
+            let resolved = false;
             let timer: NodeJS.Timeout;
             const wakeUp = () => {
+                if (resolved) return;
+                resolved = true;
                 clearTimeout(timer);
-                // Remove this wakeUp from the list if it's there (it might be called by speedUp)
                 const index = this.wakeUpSignals.indexOf(wakeUp);
                 if (index !== -1) {
                     this.wakeUpSignals.splice(index, 1);
@@ -200,6 +218,19 @@ export class ConcurrentRunner {
 
             this.wakeUpSignals.push(wakeUp);
             timer = setTimeout(wakeUp, ms);
+
+            // Lost-wake-up guard: speedUp() / setNextRunAt() called
+            // between the readiness check in runWorker and this
+            // registration cannot pop a signal that doesn't exist yet.
+            // Re-check after registration and wake immediately if any
+            // source has become due.
+            const now = Date.now();
+            for (const state of this.sources.values()) {
+                if (state.nextRunAt <= now) {
+                    wakeUp();
+                    return;
+                }
+            }
         });
     }
 

--- a/src/ConcurrentRunner.ts
+++ b/src/ConcurrentRunner.ts
@@ -203,12 +203,10 @@ export class ConcurrentRunner {
         return new Promise<void>((resolve) => {
             if (ms <= 0) return resolve();
 
-            let resolved = false;
             let timer: NodeJS.Timeout;
             const wakeUp = () => {
-                if (resolved) return;
-                resolved = true;
                 clearTimeout(timer);
+                // Remove this wakeUp from the list if it's there (it might be called by speedUp)
                 const index = this.wakeUpSignals.indexOf(wakeUp);
                 if (index !== -1) {
                     this.wakeUpSignals.splice(index, 1);
@@ -218,19 +216,6 @@ export class ConcurrentRunner {
 
             this.wakeUpSignals.push(wakeUp);
             timer = setTimeout(wakeUp, ms);
-
-            // Lost-wake-up guard: speedUp() / setNextRunAt() called
-            // between the readiness check in runWorker and this
-            // registration cannot pop a signal that doesn't exist yet.
-            // Re-check after registration and wake immediately if any
-            // source has become due.
-            const now = Date.now();
-            for (const state of this.sources.values()) {
-                if (state.nextRunAt <= now) {
-                    wakeUp();
-                    return;
-                }
-            }
         });
     }
 

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -417,7 +417,6 @@ async function runATask(): Promise<void> {
     await initPromise;
     const enforcedTask = state.enforcedTasks.shift() || null;
     let task: Task | null = null;
-    const tasksAtStart = state.tasks.size;
 
     try {
         task = await findATaskToRun(enforcedTask);
@@ -441,12 +440,10 @@ async function runATask(): Promise<void> {
         if (!task && state.runner && state.runnerStarted && state.enforcedTasks.length === 0) {
             if (state.runCronTasks) {
                 const waitMs = await getWaitTimeByNextTask();
-                // If cronTask() added a new task while getWaitTimeByNextTask
-                // was awaiting the DB, that query used a stale task filter
-                // and its waitMs may be way too long. Force an immediate
-                // re-poll so the newly registered task is picked up.
-                const readyNow = state.tasks.size > tasksAtStart || state.enforcedTasks.length > 0;
-                state.runner.setNextRunAt(CRON_SOURCE_NAME, readyNow ? Date.now() : Date.now() + waitMs);
+                // ConcurrentRunner's setNextRunAt no-ops if a concurrent
+                // speedUp() already pulled nextRunAt to the past, so our
+                // potentially-stale waitMs cannot swallow that signal.
+                state.runner.setNextRunAt(CRON_SOURCE_NAME, Date.now() + waitMs);
             } else {
                 // Once runCronTasks has been turned off and there is no
                 // enforced task to run we stop polling entirely. A later
@@ -497,13 +494,6 @@ function ensureStarted(): void {
         debug('STARTING RUNNER');
         state.runnerStarted = true;
         state.runner!.start(() => runATask());
-        // ConcurrentRunner persists source state across start/stop. A
-        // previous cycle may have left nextRunAt far in the future, which
-        // would make the fresh worker immediately sleep for the remainder
-        // of that window. Reset the schedule so the first iteration polls
-        // immediately (speedUp() fire-before-sleep-register races are
-        // moot if nextRunAt is already <= now).
-        state.runner!.setNextRunAt(CRON_SOURCE_NAME, Date.now());
     } else {
         state.runner!.speedUp(CRON_SOURCE_NAME);
     }

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -31,7 +31,7 @@ export interface InitOptions {
 }
 
 export function init(options: InitOptions): void {
-    if (state.working || state.runner) {
+    if (state.runner) {
         throw new Error('Cron tasks are already running');
     }
 
@@ -46,10 +46,7 @@ export function init(options: InitOptions): void {
     // Floor to a safe integer rather than bitwise truncation (which wraps at 32 bits).
     const requested = Number(options.cronTaskConcurrency);
     const concurrency = Math.max(1, Number.isFinite(requested) ? Math.floor(requested) : 1);
-    state.concurrency = concurrency;
-    if (concurrency > 1) {
-        state.runner = new ConcurrentRunner({ concurrency }, (error) => onError(error));
-    }
+    state.runner = new ConcurrentRunner({ concurrency }, (error) => onError(error));
 
     if (state.runCronTasks) {
         onInfo({ message: 'Cron tasks processing started', code: CODE_CRON_TASK_STARTED });
@@ -136,25 +133,17 @@ const noTaskWaitTime = 5 * 1000;
 const state = {
     tasks: new Map<string, Task>(),
 
-    // Legacy serial scheduler state (used when concurrency === 1).
-    nextTaskTimeoutId: <ReturnType<typeof setTimeout> | null>null,
-    working: false,
-    // Set by ensureStarted when it is called while the loop is already busy
-    // (working === true). The loop's finally block checks this and schedules
-    // a 0-delay next iteration so a task registered mid-iteration is never
-    // missed.
-    pendingWake: false,
-
-    // ConcurrentRunner state (used when concurrency > 1).
+    // Runner state. `runner` is created in init() and reused across
+    // start/stop cycles. `runnerStarted` tracks whether workers are
+    // currently looping. `runnerStopPromise` is non-null while a previous
+    // stop is still draining; ensureStarted chains on it so a rapid
+    // stop + start sequence waits for the previous teardown before firing
+    // a new start - otherwise ConcurrentRunner.start() is a no-op
+    // (isRunning still true) and the scheduler would stall with
+    // runnerStarted=true but no live workers.
     runner: <ConcurrentRunner | null>null,
     runnerStarted: false,
-    // Non-null while the runner is in the middle of stopping. ensureStarted
-    // chains on this promise so a rapid stop + start sequence waits for the
-    // previous teardown before firing a new start - otherwise
-    // ConcurrentRunner.start() is a no-op (isRunning still true) and the
-    // scheduler would stall with runnerStarted=true but no live workers.
     runnerStopPromise: <Promise<void> | null>null,
-    concurrency: 1,
 
     _collection: <Collection<TaskDocument> | null>null,
 
@@ -415,78 +404,20 @@ async function getWaitTimeByNextTask(): Promise<number> {
     }
 }
 
-// --- Serial scheduler (concurrency === 1) --------------------------------
-// This is the historical single-loop implementation. It is used verbatim
-// when `cronTaskConcurrency` is 1 (the default) so existing behaviour -
-// including exact wake-up timing that several tests assert on - is
-// preserved byte-for-byte.
+// --- Scheduler ---------------------------------------------------------
+// One ConcurrentRunner-driven loop for all concurrencies. Each worker
+// polls the cron collection; `findATaskToRun` uses an atomic
+// findOneAndUpdate on `lockedTill` so a task is serialised against itself
+// regardless of how many workers are running. speedUp after a successful
+// run skips the runner's back-off so a burst of pending tasks drains
+// quickly; setNextRunAt on an empty poll defers the next tick to the
+// known runSince of the soonest task.
 
-function runATask(): void {
-    debug('runATask called');
-    state.working = true;
-    state.pendingWake = false;
-    (async () => {
-        await initPromise;
-        const enforcedTask = state.enforcedTasks.shift() || null;
-        let task: Task | null = null;
-        const countOfTasks = state.tasks.size;
-
-        try {
-            task = await findATaskToRun(enforcedTask);
-
-            if (!task) {
-                debug('no pending task found');
-                return;
-            }
-
-            await processTask(task, enforcedTask);
-        } catch (error) {
-            debug(`Catch error ${error}`);
-            if (enforcedTask) {
-                enforcedTask.reject(error as Error);
-            } else {
-                onError(error as Error);
-            }
-        } finally {
-            const shouldTriggerNext = () => state.runCronTasks || !!state.enforcedTasks.length;
-            if (shouldTriggerNext()) {
-                const aTaskHasBeenRegistered = () => state.tasks.size !== countOfTasks;
-                let waitTime = 0;
-                // If ensureStarted was called while we were busy (e.g. cronTask()
-                // registered a new task mid-iteration and cleared our existing
-                // timer), re-run immediately regardless of what the DB says.
-                if (!state.pendingWake && !task && !aTaskHasBeenRegistered() && !state.enforcedTasks.length) {
-                    waitTime = await getWaitTimeByNextTask();
-                    if (state.pendingWake || aTaskHasBeenRegistered() || state.enforcedTasks.length) {
-                        waitTime = 0;
-                    }
-                }
-
-                if (shouldTriggerNext()) {
-                    debug(`SCHEDULING NEXT CHECK AFTER ${waitTime} ms`);
-                    state.nextTaskTimeoutId = setTimeout(() => {
-                        debug("it's time!");
-                        state.nextTaskTimeoutId = null;
-                        runATask();
-                    }, waitTime);
-                }
-            }
-            state.working = false;
-        }
-    })();
-}
-
-// --- Parallel scheduler (concurrency > 1) --------------------------------
-// Wraps ConcurrentRunner around the same findATaskToRun / processTask
-// primitives. Multiple workers poll the cron collection in parallel; each
-// task is still serialised against itself via the per-taskId lockedTill
-// mechanism, so raising concurrency never causes a single task to run
-// twice simultaneously.
-
-async function tryRunOneTaskViaRunner(): Promise<void> {
+async function runATask(): Promise<void> {
     await initPromise;
     const enforcedTask = state.enforcedTasks.shift() || null;
     let task: Task | null = null;
+    const tasksAtStart = state.tasks.size;
 
     try {
         task = await findATaskToRun(enforcedTask);
@@ -510,12 +441,17 @@ async function tryRunOneTaskViaRunner(): Promise<void> {
         if (!task && state.runner && state.runnerStarted && state.enforcedTasks.length === 0) {
             if (state.runCronTasks) {
                 const waitMs = await getWaitTimeByNextTask();
-                state.runner.setNextRunAt(CRON_SOURCE_NAME, Date.now() + waitMs);
+                // If cronTask() added a new task while getWaitTimeByNextTask
+                // was awaiting the DB, that query used a stale task filter
+                // and its waitMs may be way too long. Force an immediate
+                // re-poll so the newly registered task is picked up.
+                const readyNow = state.tasks.size > tasksAtStart || state.enforcedTasks.length > 0;
+                state.runner.setNextRunAt(CRON_SOURCE_NAME, readyNow ? Date.now() : Date.now() + waitMs);
             } else {
-                // Mirror the serial scheduler: once runCronTasks has been
-                // turned off and there is no enforced task to run we stop
-                // polling entirely. A later runCronTask() / startCronTasks()
-                // will re-enter ensureStarted which restarts the runner.
+                // Once runCronTasks has been turned off and there is no
+                // enforced task to run we stop polling entirely. A later
+                // runCronTask() / startCronTasks() will re-enter
+                // ensureStarted which restarts the runner.
                 state.runnerStarted = false;
                 // Track the stop promise here too so a rapid runCronTask()
                 // call that arrives mid-drain chains on it in ensureStarted
@@ -529,71 +465,56 @@ async function tryRunOneTaskViaRunner(): Promise<void> {
 }
 
 function ensureStarted(): void {
-    if (state.runner) {
-        // Parallel path.
-        // If a previous stopCronTasks() is still draining the runner, wait
-        // for it before (re)starting. Without this the inner start() call
-        // would no-op (isRunning still true) and we would end up with
-        // runnerStarted=true but no actual workers.
-        if (state.runnerStopPromise) {
-            const pending = state.runnerStopPromise;
-            pending
-                .then(() => {
-                    if (state.runnerStopPromise === pending) {
-                        state.runnerStopPromise = null;
-                    }
-                    // Re-evaluate: cron may have been stopped again in the
-                    // meantime or runCronTasks may have flipped off.
-                    if (state.runCronTasks || state.enforcedTasks.length > 0) {
-                        ensureStarted();
-                    }
-                })
-                .catch((err) => onError(err as Error));
-            return;
-        }
-
-        if (!state.runner.hasSource(CRON_SOURCE_NAME)) {
-            state.runner.registerSource(CRON_SOURCE_NAME, {
-                minPollMs: 200,
-                maxPollMs: noTaskWaitTime,
-                jitterMs: 100,
-            });
-        }
-        if (!state.runnerStarted) {
-            debug('STARTING RUNNER');
-            state.runnerStarted = true;
-            state.runner.start(() => tryRunOneTaskViaRunner());
-        } else {
-            state.runner.speedUp(CRON_SOURCE_NAME);
-        }
+    // If a previous stopCronTasks() is still draining the runner, wait
+    // for it before (re)starting. Without this the inner start() call
+    // would no-op (isRunning still true) and we would end up with
+    // runnerStarted=true but no actual workers.
+    if (state.runnerStopPromise) {
+        const pending = state.runnerStopPromise;
+        pending
+            .then(() => {
+                if (state.runnerStopPromise === pending) {
+                    state.runnerStopPromise = null;
+                }
+                // Re-evaluate: cron may have been stopped again in the
+                // meantime or runCronTasks may have flipped off.
+                if (state.runCronTasks || state.enforcedTasks.length > 0) {
+                    ensureStarted();
+                }
+            })
+            .catch((err) => onError(err as Error));
         return;
     }
 
-    // Serial path.
-    if (state.nextTaskTimeoutId) {
-        clearTimeout(state.nextTaskTimeoutId);
-        state.nextTaskTimeoutId = null;
+    if (!state.runner!.hasSource(CRON_SOURCE_NAME)) {
+        state.runner!.registerSource(CRON_SOURCE_NAME, {
+            minPollMs: 200,
+            maxPollMs: noTaskWaitTime,
+            jitterMs: 100,
+        });
     }
-    if (state.working) {
-        // The loop is mid-iteration. It will notice pendingWake in its
-        // finally block and schedule the next iteration at 0ms.
-        state.pendingWake = true;
-        return;
+    if (!state.runnerStarted) {
+        debug('STARTING RUNNER');
+        state.runnerStarted = true;
+        state.runner!.start(() => runATask());
+        // ConcurrentRunner persists source state across start/stop. A
+        // previous cycle may have left nextRunAt far in the future, which
+        // would make the fresh worker immediately sleep for the remainder
+        // of that window. Reset the schedule so the first iteration polls
+        // immediately (speedUp() fire-before-sleep-register races are
+        // moot if nextRunAt is already <= now).
+        state.runner!.setNextRunAt(CRON_SOURCE_NAME, Date.now());
+    } else {
+        state.runner!.speedUp(CRON_SOURCE_NAME);
     }
-    debug('STARTING LOOP');
-    runATask();
 }
 
 export function stopCronTasks(): void {
     debug('STOPPING CRON TASKS');
     state.runCronTasks = false;
-    if (state.nextTaskTimeoutId) {
-        clearTimeout(state.nextTaskTimeoutId);
-        state.nextTaskTimeoutId = null;
-    }
     if (state.runner && state.runnerStarted) {
         state.runnerStarted = false;
-        // Fire and forget: the historical API is synchronous (returns void).
+        // Fire and forget: the public API is synchronous (returns void).
         // Any in-flight tasks will finish on their own; further polls will
         // not happen because runnerStarted is already cleared. Track the
         // stop promise so ensureStarted can chain on it if the caller

--- a/src/reactiveTasks/MONITORING.md
+++ b/src/reactiveTasks/MONITORING.md
@@ -31,7 +31,8 @@ Track the core work being done by workers.
 **Source:** Computed by the Leader (on-scrape, fresh). In `cluster`
 mode the Leader also bundles these values into the registry document
 on each push so a scrape that lands on a Follower still returns them
-(bounded staleness: at most one `pushIntervalMs`).
+(bounded staleness: up to `2 x pushIntervalMs`; one missed push is
+tolerated, two in a row stop serving the gauge).
 
 | Metric Name | Type | Labels | Description | Typical Question |
 | :--- | :--- | :--- | :--- | :--- |
@@ -122,7 +123,11 @@ db.globals.updateOne(
 - Focuses on scheduling.
 
 #### `LeaderElector`
-- Used by `MetricsCollector` to check `amILeader()` for `scrapeMode: 'leader'`.
+- Used by `MetricsCollector` to check `isLeader` in both scrape modes:
+  in `local` the leader adds fresh global stats to its own scrape; in
+  `cluster` only the leader's push writes the `globalStats` field, and
+  on scrape only the leader uses the fresh on-the-fly values
+  (followers read what the current leader pushed).
 
 ### Proposed Changes
 

--- a/src/reactiveTasks/MONITORING.md
+++ b/src/reactiveTasks/MONITORING.md
@@ -15,7 +15,8 @@ The monitoring behavior can be customized via the `monitoring` options object pa
 | `enabled` | boolean | `true` | Enable/disable metrics collection. |
 | `pushIntervalMs` | number | `60000` (1m) | How often workers push local metrics to the global registry. |
 | `registry` | `prom-client.Registry` | `undefined` | Optional custom Prometheus registry instance. |
-| `scrapeMode` | `'cluster' \| 'local'` | `'cluster'` | Controls which instances return metrics when scraped. <br> **'cluster'**: All instances return full aggregated metrics. Use when scraping via Load Balancer (Heroku). <br> **'local'**: Returns local metrics for THIS instance. Leader also includes Global Stats. |
+| `scrapeMode` | `'cluster' \| 'local'` | `'cluster'` | Controls which instances return metrics when scraped. <br> **'cluster'**: All instances return full aggregated metrics incl. global stats. Use when scraping via Load Balancer (Heroku). <br> **'local'**: Returns local metrics for THIS instance. Leader also includes Global Stats. |
+| `readPreference` | `ReadPreference` | `'secondaryPreferred'` | Read preference for DB queries that compute global stats and fetch the registry doc. |
 
 ### Task Execution Metrics
 Track the core work being done by workers.
@@ -27,7 +28,10 @@ Track the core work being done by workers.
 | `reactive_tasks_retries_total` | Counter | `task_name` | Total number of retries attempted. | "Is a specific task failing frequently?" |
 
 ### Queue & Scheduler Metrics
-**Source:** Computed on-demand via DB Query during scrape.
+**Source:** Computed by the Leader (on-scrape, fresh). In `cluster`
+mode the Leader also bundles these values into the registry document
+on each push so a scrape that lands on a Follower still returns them
+(bounded staleness: at most one `pushIntervalMs`).
 
 | Metric Name | Type | Labels | Description | Typical Question |
 | :--- | :--- | :--- | :--- | :--- |
@@ -35,7 +39,8 @@ Track the core work being done by workers.
 | `reactive_tasks_global_lag_seconds` | Gauge | `task_name` | Age of oldest pending task (`Now - ScheduledAt`). | "Is the system stalling?" |
 
 ### System & Infrastructure Metrics
-**Source:** Computed on-demand via DB Query during scrape.
+**Source:** Same as Queue & Scheduler Metrics - fresh on the Leader,
+bounded-stale on Followers via the registry doc push.
 
 | Metric Name | Type | Labels | Description | Typical Question |
 | :--- | :--- | :--- | :--- | :--- |
@@ -47,8 +52,15 @@ Track the core work being done by workers.
 ## 2. Implementation Plan (Distributed)
 
 We use a **Hybrid Metrics Pattern**:
-1.  **Worker Stats**: Pushed by workers to a central Registry Document, aggregated on read.
-2.  **Global Stats**: Queried directly from DB on read.
+1.  **Worker Stats**: Pushed by every instance to a central Registry Document, aggregated on read.
+2.  **Global Stats**:
+    - On the Leader: queried directly from DB on read (fresh values).
+    - Also periodically pushed to a dedicated `globalStats` field on the
+      same Registry Document, so a Follower served scrape in `cluster`
+      mode can return a complete metrics view without doing the DB work
+      itself. The field is a singleton (one writer at a time - the
+      current Leader), preventing double-counting across leader
+      transitions.
 
 > [!NOTE]
 > `prom-client` will be an **optional peerDependency**.
@@ -58,21 +70,32 @@ We use a **Hybrid Metrics Pattern**:
 We expose a method `getPrometheusMetrics()` that decides whether to return metrics based on `scrapeMode`.
 
 #### `scrapeMode` Logic
-- **`'any'` (Single Instance Reporting)**:
+- **`'cluster'` (default)**:
     - Useful for Heroku / Load Balanced setups.
-    - **Any instance** that receives the request will fetch the Registry and query Global Stats, returning the full set.
-- **`'leader'` (Multi Instance Reporting)**:
+    - **Any instance** that receives the request returns the full set:
+      per-instance stats merged from the Registry Document + global
+      stats (fresh on the Leader, last-pushed on Followers).
+- **`'local'`**:
     - Useful for K8s / Service Discovery where Prometheus scrapes *everyone*.
-    - **Only the Leader** performs the aggregation and DB queries. Non-leaders return empty/null (or just app-level node metrics if configured elsewhere).
-    - Prevents double-counting of the aggregated Registry data.
+    - Each instance returns only its own per-instance stats. The Leader
+      additionally includes the fresh Global Stats, so those are
+      reported exactly once in the cluster.
+    - No double-counting - followers only ever emit their own locals.
 
 #### `MetricsCollector`
-- **Push Loop**: Periodically pushes *local* worker stats (`duration`, `retries`) to `reactive_tasks_metrics_registry`.
-- **Scrape Handler**:
-    1. Check `scrapeMode` & Leadership.
-    2. **Fetch Registry**: Read `reactive_tasks_metrics_registry`, prune stale instances in-memory, sum up worker stats.
-    3. **Query DB**: Run `queue_depth` aggregation and `lag` queries.
-    4. **Combine**: Update the Prometheus Registry and return string.
+- **Push Loop** (every `pushIntervalMs`):
+    - Every instance pushes its own local registry metrics into the
+      `instances[]` array of `reactive_tasks_metrics_registry`.
+    - The Leader additionally pushes fresh global stats into the
+      `globalStats` field of the same document.
+- **Scrape Handler** (cluster mode):
+    1. Read `reactive_tasks_metrics_registry` once; prune stale
+       instances in-memory (sum up worker stats).
+    2. Include this instance's own fresh local metrics.
+    3. Include global stats: the Leader runs the DB queries on the
+       spot for freshest values; Followers fall back to the
+       `globalStats` field from step 1 (pruned if stale).
+    4. Aggregate everything via `AggregatorRegistry.aggregate`.
 
 ### Pruning Strategy
 - Stale instances in `reactive_tasks_metrics_registry` are filtered out **during the scrape aggregation** (`lastSeen < Now - threshold`).

--- a/src/reactiveTasks/MetricsCollector.ts
+++ b/src/reactiveTasks/MetricsCollector.ts
@@ -36,12 +36,13 @@ const STALE_THRESHOLD_MULTIPLIER = 20;
 /**
  * The leader-pushed `globalStats` blob is treated as stale sooner than
  * per-instance local metrics: it reflects a point-in-time DB query
- * (queue depth / lag) and is meaningless if the leader stopped pushing.
- * A tighter bound keeps follower-served gauges close to the stated
- * "bounded by pushIntervalMs" contract while still tolerating a single
- * missed push (e.g. slow DB on the leader).
+ * (queue depth / lag) and is meaningless once the leader stops pushing.
+ * With `2 * pushIntervalMs`, a single missed push (e.g. slow DB on the
+ * leader) still serves the last known value; two missed pushes in a
+ * row stop serving the gauge. Cluster-mode follower gauges are thus
+ * bounded-stale at `GLOBAL_STATS_STALE_MULTIPLIER * pushIntervalMs`.
  */
-const GLOBAL_STATS_STALE_MULTIPLIER = 3;
+const GLOBAL_STATS_STALE_MULTIPLIER = 2;
 
 const DEFAULT_PUSH_INTERVAL = 60000;
 
@@ -78,8 +79,9 @@ const DEFAULT_OPTIONS: Required<Pick<MonitoringOptions, 'enabled' | 'scrapeMode'
  * Global stats (queue depth, lag, change-stream lag, reconciliation timestamp)
  * are computed by the Leader. In `cluster` mode the Leader also pushes these
  * values into the registry document on each push interval so a scrape that
- * lands on a Follower still returns a complete metrics view - bounded by
- * `pushIntervalMs` staleness.
+ * lands on a Follower still returns a complete metrics view - bounded-stale
+ * at `GLOBAL_STATS_STALE_MULTIPLIER * pushIntervalMs` (2x by default,
+ * i.e. a single missed push is tolerated).
  */
 export class MetricsCollector {
     // Configuration

--- a/src/reactiveTasks/MetricsCollector.ts
+++ b/src/reactiveTasks/MetricsCollector.ts
@@ -24,7 +24,25 @@ const METRIC_NAMES = {
 };
 
 const REGISTRY_DOC_ID = 'reactive_tasks_metrics_registry';
+
+/**
+ * Instance entries older than this many push intervals are ignored
+ * during scrape aggregation and pruned by the leader's next push.
+ * Generous because an instance could be briefly unreachable but still
+ * alive; its counters are cumulative anyway.
+ */
 const STALE_THRESHOLD_MULTIPLIER = 20;
+
+/**
+ * The leader-pushed `globalStats` blob is treated as stale sooner than
+ * per-instance local metrics: it reflects a point-in-time DB query
+ * (queue depth / lag) and is meaningless if the leader stopped pushing.
+ * A tighter bound keeps follower-served gauges close to the stated
+ * "bounded by pushIntervalMs" contract while still tolerating a single
+ * missed push (e.g. slow DB on the leader).
+ */
+const GLOBAL_STATS_STALE_MULTIPLIER = 3;
+
 const DEFAULT_PUSH_INTERVAL = 60000;
 
 /**
@@ -389,7 +407,7 @@ export class MetricsCollector {
             let pushedGlobalStats: MetricsJson | null = null;
             if (registryDoc.globalStats && Array.isArray(registryDoc.globalStats.metrics)) {
                 const age = now - new Date(registryDoc.globalStats.updatedAt).getTime();
-                if (age <= staleThreshold) {
+                if (age <= GLOBAL_STATS_STALE_MULTIPLIER * this.options.pushIntervalMs) {
                     pushedGlobalStats = registryDoc.globalStats.metrics as MetricsJson;
                 }
             }

--- a/src/reactiveTasks/MetricsCollector.ts
+++ b/src/reactiveTasks/MetricsCollector.ts
@@ -477,8 +477,14 @@ export class MetricsCollector {
         try {
             const threshold = STALE_THRESHOLD_MULTIPLIER * this.options.pushIntervalMs;
 
+            // Re-check leadership immediately before emitting the pipeline
+            // so a transition that happened during `getGlobalStatsAsJson()`
+            // doesn't let a former leader overwrite the shared globalStats
+            // blob after stepping down.
+            const stillLeader = this.leaderElector.isLeader;
+
             // Leader cleans up stale instances; followers only update self
-            const keepCondition = this.leaderElector.isLeader
+            const keepCondition = stillLeader
                 ? { $and: [{ $ne: ['$$inst.id', this.instanceId] }, { $lt: [{ $subtract: ['$$NOW', '$$inst.lastSeen'] }, threshold] }] }
                 : { $ne: ['$$inst.id', this.instanceId] };
 
@@ -494,7 +500,7 @@ export class MetricsCollector {
                     },
                 },
             ];
-            if (globalStats) {
+            if (globalStats && stillLeader) {
                 pipeline.push({
                     $set: {
                         globalStats: { updatedAt: '$$NOW', leaderId: this.instanceId, metrics: globalStats },

--- a/src/reactiveTasks/MetricsCollector.ts
+++ b/src/reactiveTasks/MetricsCollector.ts
@@ -27,6 +27,14 @@ const REGISTRY_DOC_ID = 'reactive_tasks_metrics_registry';
 const STALE_THRESHOLD_MULTIPLIER = 20;
 const DEFAULT_PUSH_INTERVAL = 60000;
 
+/**
+ * Shape returned by `Registry.getMetricsAsJSON()` and consumed by
+ * `AggregatorRegistry.aggregate()`. Used for both local-instance
+ * metrics pushed into `instances[].metrics` and the Leader's bundled
+ * global stats stored under `globalStats.metrics`.
+ */
+type MetricsJson = MetricObjectWithValues<MetricValue<string>>[];
+
 type MonitoringOptions = NonNullable<ReactiveTaskSchedulerOptions['monitoring']>;
 
 const DEFAULT_OPTIONS: Required<Pick<MonitoringOptions, 'enabled' | 'scrapeMode' | 'readPreference' | 'pushIntervalMs'>> = {
@@ -296,7 +304,7 @@ export class MetricsCollector {
      * returns queue depth / lag / reconciliation / stream-lag gauges).
      */
     private async getClusterMetrics(): Promise<Registry | null> {
-        const allMetrics: object[] = [];
+        const allMetrics: MetricsJson[] = [];
 
         // 1. Fetch other instances' local metrics AND last-pushed global stats.
         const { otherInstancesMetrics, pushedGlobalStats } = await this.fetchClusterStateFromDb();
@@ -353,7 +361,7 @@ export class MetricsCollector {
     // Metrics Data Fetching
     // ========================================================================
 
-    private async fetchClusterStateFromDb(): Promise<{ otherInstancesMetrics: object[]; pushedGlobalStats: object | null }> {
+    private async fetchClusterStateFromDb(): Promise<{ otherInstancesMetrics: MetricsJson[]; pushedGlobalStats: MetricsJson | null }> {
         try {
             const registryDoc = (await this.globalsCollection.findOne(
                 { _id: REGISTRY_DOC_ID },
@@ -367,7 +375,7 @@ export class MetricsCollector {
             const now = Date.now();
             const staleThreshold = STALE_THRESHOLD_MULTIPLIER * this.options.pushIntervalMs;
 
-            const otherInstancesMetrics = Array.isArray(registryDoc.instances)
+            const otherInstancesMetrics: MetricsJson[] = Array.isArray(registryDoc.instances)
                 ? registryDoc.instances
                       .filter((inst) => {
                           const age = now - new Date(inst.lastSeen).getTime();
@@ -375,14 +383,14 @@ export class MetricsCollector {
                           const isSelf = inst.id === this.instanceId;
                           return !isStale && !isSelf && Array.isArray(inst.metrics);
                       })
-                      .map((inst) => inst.metrics as object[])
+                      .map((inst) => inst.metrics as MetricsJson)
                 : [];
 
-            let pushedGlobalStats: object | null = null;
+            let pushedGlobalStats: MetricsJson | null = null;
             if (registryDoc.globalStats && Array.isArray(registryDoc.globalStats.metrics)) {
                 const age = now - new Date(registryDoc.globalStats.updatedAt).getTime();
                 if (age <= staleThreshold) {
-                    pushedGlobalStats = registryDoc.globalStats.metrics as object;
+                    pushedGlobalStats = registryDoc.globalStats.metrics as MetricsJson;
                 }
             }
 
@@ -393,7 +401,7 @@ export class MetricsCollector {
         }
     }
 
-    private async getLocalMetricsAsJson(): Promise<object | null> {
+    private async getLocalMetricsAsJson(): Promise<MetricsJson | null> {
         if (!this.localPromRegistry) return null;
 
         try {
@@ -404,7 +412,7 @@ export class MetricsCollector {
         }
     }
 
-    private async getGlobalStatsAsJson(): Promise<object | null> {
+    private async getGlobalStatsAsJson(): Promise<MetricsJson | null> {
         if (!this.leaderElector.isLeader || !this.globalStatsRegistry) return null;
 
         try {
@@ -445,7 +453,7 @@ export class MetricsCollector {
         }
     }
 
-    private async publishMetricsToGlobalRegistry(localMetrics: MetricObjectWithValues<MetricValue<string>>[], globalStats: object | null): Promise<void> {
+    private async publishMetricsToGlobalRegistry(localMetrics: MetricsJson, globalStats: MetricsJson | null): Promise<void> {
         try {
             const threshold = STALE_THRESHOLD_MULTIPLIER * this.options.pushIntervalMs;
 

--- a/src/reactiveTasks/MetricsCollector.ts
+++ b/src/reactiveTasks/MetricsCollector.ts
@@ -1,3 +1,4 @@
+import type { Document } from 'mongodb';
 import type { Counter, Gauge, Histogram, MetricObjectWithValues, MetricValue, Registry } from 'prom-client';
 import { GlobalsCollection } from '../globalsCollection';
 import { defaultOnError, OnError } from '../OnError';
@@ -48,7 +49,11 @@ const DEFAULT_OPTIONS: Required<Pick<MonitoringOptions, 'enabled' | 'scrapeMode'
  * - **local**: Returns metrics from THIS instance only.
  *   Use when Prometheus scrapes each pod individually (K8s Pod Monitors).
  *
- * Global stats (queue depth, lag) are computed on-the-fly by the **Leader only**.
+ * Global stats (queue depth, lag, change-stream lag, reconciliation timestamp)
+ * are computed by the Leader. In `cluster` mode the Leader also pushes these
+ * values into the registry document on each push interval so a scrape that
+ * lands on a Follower still returns a complete metrics view - bounded by
+ * `pushIntervalMs` staleness.
  */
 export class MetricsCollector {
     // Configuration
@@ -286,22 +291,29 @@ export class MetricsCollector {
     /**
      * Returns aggregated metrics from ALL instances.
      * Fetches other instances' metrics from DB and merges with fresh local metrics.
-     * Leader also includes global stats.
+     * Global stats: leader computes fresh; followers read the leader's last
+     * push from the registry doc (so a scrape that hits a follower still
+     * returns queue depth / lag / reconciliation / stream-lag gauges).
      */
     private async getClusterMetrics(): Promise<Registry | null> {
         const allMetrics: object[] = [];
 
-        // 1. Fetch other instances' metrics from DB
-        const otherInstanceMetrics = await this.fetchOtherInstancesMetrics();
-        allMetrics.push(...otherInstanceMetrics);
+        // 1. Fetch other instances' local metrics AND last-pushed global stats.
+        const { otherInstancesMetrics, pushedGlobalStats } = await this.fetchClusterStateFromDb();
+        allMetrics.push(...otherInstancesMetrics);
 
-        // 2. Add fresh local metrics
+        // 2. Add fresh local metrics from this instance.
         const localMetrics = await this.getLocalMetricsAsJson();
         if (localMetrics) allMetrics.push(localMetrics);
 
-        // 3. If leader, add global stats
-        const globalStats = await this.getGlobalStatsAsJson();
-        if (globalStats) allMetrics.push(globalStats);
+        // 3. Global stats: leader uses fresh on-the-fly values; followers
+        //    fall back to what the current leader last pushed.
+        if (this.leaderElector.isLeader) {
+            const freshGlobalStats = await this.getGlobalStatsAsJson();
+            if (freshGlobalStats) allMetrics.push(freshGlobalStats);
+        } else if (pushedGlobalStats) {
+            allMetrics.push(pushedGlobalStats);
+        }
 
         // 4. Aggregate all
         if (allMetrics.length === 0) return null;
@@ -341,31 +353,43 @@ export class MetricsCollector {
     // Metrics Data Fetching
     // ========================================================================
 
-    private async fetchOtherInstancesMetrics(): Promise<object[]> {
+    private async fetchClusterStateFromDb(): Promise<{ otherInstancesMetrics: object[]; pushedGlobalStats: object | null }> {
         try {
             const registryDoc = (await this.globalsCollection.findOne(
                 { _id: REGISTRY_DOC_ID },
                 { readPreference: this.options.readPreference },
             )) as RegistryDocument | null;
 
-            if (!registryDoc?.instances || !Array.isArray(registryDoc.instances)) {
-                return [];
+            if (!registryDoc) {
+                return { otherInstancesMetrics: [], pushedGlobalStats: null };
             }
 
             const now = Date.now();
             const staleThreshold = STALE_THRESHOLD_MULTIPLIER * this.options.pushIntervalMs;
 
-            return registryDoc.instances
-                .filter((inst) => {
-                    const age = now - new Date(inst.lastSeen).getTime();
-                    const isStale = age > staleThreshold;
-                    const isSelf = inst.id === this.instanceId;
-                    return !isStale && !isSelf && Array.isArray(inst.metrics);
-                })
-                .map((inst) => inst.metrics as object[]);
+            const otherInstancesMetrics = Array.isArray(registryDoc.instances)
+                ? registryDoc.instances
+                      .filter((inst) => {
+                          const age = now - new Date(inst.lastSeen).getTime();
+                          const isStale = age > staleThreshold;
+                          const isSelf = inst.id === this.instanceId;
+                          return !isStale && !isSelf && Array.isArray(inst.metrics);
+                      })
+                      .map((inst) => inst.metrics as object[])
+                : [];
+
+            let pushedGlobalStats: object | null = null;
+            if (registryDoc.globalStats && Array.isArray(registryDoc.globalStats.metrics)) {
+                const age = now - new Date(registryDoc.globalStats.updatedAt).getTime();
+                if (age <= staleThreshold) {
+                    pushedGlobalStats = registryDoc.globalStats.metrics as object;
+                }
+            }
+
+            return { otherInstancesMetrics, pushedGlobalStats };
         } catch (e) {
             this.onError(e as Error);
-            return [];
+            return { otherInstancesMetrics: [], pushedGlobalStats: null };
         }
     }
 
@@ -409,14 +433,19 @@ export class MetricsCollector {
         if (!this.localPromRegistry) return;
 
         try {
-            const metricsJson = await this.localPromRegistry.getMetricsAsJSON();
-            await this.publishMetricsToGlobalRegistry(metricsJson);
+            const localMetrics = await this.localPromRegistry.getMetricsAsJSON();
+            // Leader bundles the freshly computed global stats into the
+            // registry document so follower-served scrapes in cluster
+            // mode return a complete metrics view. Non-leaders write
+            // only their local metrics.
+            const globalStatsToPush = this.leaderElector.isLeader ? await this.getGlobalStatsAsJson() : null;
+            await this.publishMetricsToGlobalRegistry(localMetrics, globalStatsToPush);
         } catch (e) {
             this.onError(e as Error);
         }
     }
 
-    private async publishMetricsToGlobalRegistry(metrics: MetricObjectWithValues<MetricValue<string>>[]): Promise<void> {
+    private async publishMetricsToGlobalRegistry(localMetrics: MetricObjectWithValues<MetricValue<string>>[], globalStats: object | null): Promise<void> {
         try {
             const threshold = STALE_THRESHOLD_MULTIPLIER * this.options.pushIntervalMs;
 
@@ -425,22 +454,27 @@ export class MetricsCollector {
                 ? { $and: [{ $ne: ['$$inst.id', this.instanceId] }, { $lt: [{ $subtract: ['$$NOW', '$$inst.lastSeen'] }, threshold] }] }
                 : { $ne: ['$$inst.id', this.instanceId] };
 
-            await this.globalsCollection.updateOne(
-                { _id: REGISTRY_DOC_ID },
-                [
-                    {
-                        $set: {
-                            instances: {
-                                $concatArrays: [
-                                    { $filter: { input: { $ifNull: ['$instances', []] }, as: 'inst', cond: keepCondition } },
-                                    [{ id: this.instanceId, lastSeen: '$$NOW', metrics }],
-                                ],
-                            },
+            const pipeline: Document[] = [
+                {
+                    $set: {
+                        instances: {
+                            $concatArrays: [
+                                { $filter: { input: { $ifNull: ['$instances', []] }, as: 'inst', cond: keepCondition } },
+                                [{ id: this.instanceId, lastSeen: '$$NOW', metrics: localMetrics }],
+                            ],
                         },
                     },
-                ],
-                { upsert: true },
-            );
+                },
+            ];
+            if (globalStats) {
+                pipeline.push({
+                    $set: {
+                        globalStats: { updatedAt: '$$NOW', leaderId: this.instanceId, metrics: globalStats },
+                    },
+                });
+            }
+
+            await this.globalsCollection.updateOne({ _id: REGISTRY_DOC_ID }, pipeline, { upsert: true });
         } catch (e) {
             this.onError(e as Error);
         }

--- a/src/reactiveTasks/ReactiveTaskTypes.ts
+++ b/src/reactiveTasks/ReactiveTaskTypes.ts
@@ -121,6 +121,19 @@ export interface RegistryDocument {
         lastSeen: Date | string; // Date or $$NOW string
         metrics: unknown; // MetricObjectWithValues[]
     }>;
+    /**
+     * Cluster-wide stats (queue depth, global lag, change-stream lag,
+     * last reconciliation). Written only by the current Leader on each
+     * push; non-leaders read it so that a follower-served scrape in
+     * `cluster` mode can return a complete metrics view. A single field
+     * (not per-instance) prevents double-counting across leader
+     * transitions - the next leader overwrites on its first push.
+     */
+    globalStats?: {
+        updatedAt: Date | string; // Date or $$NOW
+        leaderId: string;
+        metrics: unknown; // MetricObjectWithValues[]
+    };
 }
 
 /**

--- a/test/ConcurrentRunner.ts
+++ b/test/ConcurrentRunner.ts
@@ -193,4 +193,98 @@ describe('ConcurrentRunner', () => {
         await runner.stop();
         await runner.stop(); // Should be safe
     });
+
+    // ------------------------------------------------------------------
+    // Scheduler-race regressions. Each `it` pins a specific behaviour
+    // introduced by the "close three scheduler races" refactor.
+    // ------------------------------------------------------------------
+
+    it('start() resets source schedule so a restart polls immediately despite prolonged nextRunAt', async () => {
+        // High minPoll so the worker's natural back-off is much longer
+        // than this test's window. Without the source reset in start()
+        // the restarted worker would inherit a `nextRunAt = ~now + 1s`
+        // set by prolongNextRun in the previous cycle and sleep the rest
+        // of that 1s before noticing any new work.
+        runner = new ConcurrentRunner({ concurrency: 1 });
+        runner.registerSource('col1', { minPollMs: 1000, maxPollMs: 1000, jitterMs: 0 });
+
+        let callCount = 0;
+        const callback = async () => {
+            callCount++;
+        };
+
+        // Cycle 1: one poll + worker enters sleep with prolonged nextRunAt.
+        runner.start(callback);
+        await sleep(30);
+        expect(callCount).toBeGreaterThanOrEqual(1);
+
+        // Stop mid-sleep. Source metadata (nextRunAt ~= now + 1000) persists.
+        await runner.stop();
+
+        const callsAfterRestart = callCount;
+
+        // Cycle 2: restart. If start() resets nextRunAt to `now`, the
+        // fresh worker polls immediately. Without the reset the first
+        // iteration would compute timeToWait from the stale 1000ms value
+        // and sleep ~950ms, missing our 100ms assertion window.
+        runner.start(callback);
+        await sleep(100);
+
+        expect(callCount).toBeGreaterThan(callsAfterRestart);
+    });
+
+    it('setNextRunAt() after a concurrent speedUp does not push the signal back into the future', async () => {
+        // Reproduces the race surfaced by cron tests: a task callback
+        // (a) triggers speedUp to signal new work while running, and
+        // (b) on return the scheduler commits setNextRunAt with a large
+        // waitMs computed from pre-signal state. Without the no-op guard
+        // (state.nextRunAt <= now  =>  skip write) setNextRunAt wins
+        // and the signalled immediate poll is lost.
+        runner = new ConcurrentRunner({ concurrency: 1 });
+        runner.registerSource('col1', { minPollMs: 5000, maxPollMs: 5000, jitterMs: 0 });
+
+        let callCount = 0;
+        let signalled = false;
+        runner.start(async () => {
+            callCount++;
+            if (!signalled) {
+                signalled = true;
+                runner.speedUp('col1');
+                runner.setNextRunAt('col1', Date.now() + 60 * 60 * 1000);
+            }
+        });
+
+        // minPollMs is 5000ms. Without the fix the worker would sleep
+        // the full 5000ms after the first invocation and this 200ms
+        // window would see only a single call. With the fix speedUp
+        // survives and the worker invokes callback at least twice.
+        await sleep(200);
+        expect(callCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it('setNextRunAt() with a future runAt still applies when nextRunAt is already future', async () => {
+        // Negative case for the no-op guard: the standard "push next
+        // poll forward" usage must continue to work when no speedUp
+        // has pulled nextRunAt into the past.
+        runner = new ConcurrentRunner({ concurrency: 1 });
+        runner.registerSource('col1', { minPollMs: 50, maxPollMs: 50, jitterMs: 0 });
+
+        let callCount = 0;
+        runner.start(async () => {
+            callCount++;
+        });
+
+        // Let one poll run; prolongNextRun sets nextRunAt ~= now + 50ms
+        // (safely in the future from Date.now()'s perspective).
+        await sleep(20);
+        const callsAfterFirst = callCount;
+        expect(callsAfterFirst).toBeGreaterThanOrEqual(1);
+
+        // Push next poll far beyond that back-off; write must apply.
+        runner.setNextRunAt('col1', Date.now() + 1000);
+
+        // Well past the 50ms back-off, well before the 1000ms target.
+        await sleep(200);
+        expect(callCount).toBe(callsAfterFirst);
+    });
 });

--- a/test/reactiveTasks/monitoring.test.ts
+++ b/test/reactiveTasks/monitoring.test.ts
@@ -824,9 +824,11 @@ describe('Reactive Task Monitoring', () => {
         expect(followerRegistry).toBeDefined();
         const followerJson = await followerRegistry!.getMetricsAsJSON();
 
-        // Follower should NOT have Global Stats (computed only by leader)
-        expect(find(followerJson, { name: 'reactive_tasks_queue_depth' })).toBeUndefined();
-        expect(find(followerJson, { name: 'reactive_tasks_global_lag_seconds' })).toBeUndefined();
+        // Follower should now include Global Stats too: the leader pushes them
+        // to the registry doc on each interval, and the follower reads them
+        // there. Freshness is bounded by pushIntervalMs (100 in this test).
+        expect(find(followerJson, { name: 'reactive_tasks_queue_depth' })).toBeDefined();
+        expect(find(followerJson, { name: 'reactive_tasks_global_lag_seconds' })).toBeDefined();
 
         // Follower should have Duration metrics (aggregated from all instances including itself)
         const followerDuration = find(followerJson, { name: 'reactive_tasks_duration_seconds' });
@@ -870,56 +872,35 @@ describe('Reactive Task Monitoring', () => {
     });
 
     it('should return aggregated metrics (including external Global Stats) when in Cluster Mode as Follower', async () => {
+        // Single-instance cluster: the instance becomes Leader on start
+        // and MetricsCollector.start() pushes both local metrics and the
+        // fresh global stats to the registry doc immediately. A follower
+        // scrape (simulated by stubbing `isLeader` to false afterwards)
+        // must return the previously-pushed global stats from the DB -
+        // the whole point of the "cluster" mode contract documented in
+        // docs/reactive-tasks/monitoring.md.
         await instance.initInstance({
             globalsCollection: GLOBAL_COLLECTION_NAME,
-            monitoring: { enabled: true, scrapeMode: 'cluster' },
+            monitoring: { enabled: true, scrapeMode: 'cluster', pushIntervalMs: 100 },
         });
 
         await instance.mongodash.startReactiveTasks();
+        // Wait long enough for election + a push cycle so globalStats
+        // lands in the registry doc.
         await wait(500);
 
         const scheduler = (instance.mongodash as any)._scheduler;
-        // Mock Follower role
         sinon.stub(scheduler.leaderElector, 'isLeader').get(() => false);
-
-        // Mock DB State: Another instance is Leader and pushed Global Stats (or at least unrelated metrics)
-        // Note: Global Stats (Queue/Lag) are usually computed on-the-fly and NOT pushed to DB 'instances' array.
-        // Wait, MetricsCollector implementation:
-        // "We do NOT push Global Stats to the DB registry doc, only Local/Instance stats."
-        // "Global stats are calculated on-the-fly by the Leader."
-
-        // IF we are a Follower in Cluster Mode:
-        // getAggregatedRegistry -> reads DB instances (aggregated local stats)
-        // It DOES NOT compute Global Stats because !isLeader.
-        // It DOES NOT fetch Global Stats from DB because they aren't there.
-        //
-        // So a Follower in Cluster Mode will return Aggregated Local Metrics (Duration/Retries) from all nodes,
-        // BUT IT WILL MISS GLOBAL STATS (Queue/Lag) unless the Leader is pushing them?
-        //
-        // Re-reading MetricsCollector.ts:
-        // "Global stats are calculated on-the-fly by the Leader."
-        // "We do NOT push Global Stats to the DB registry doc"
-        //
-        // This means if you hit a Follower's /metrics endpoint in Cluster Mode, you will NOT get Queue Depth / Lag.
-        // You only get them if you hit the Leader.
-        // UNLESS the aggregated view was supposed to include them?
-        // If they are not in DB, Follower cannot see them.
-        // The only way Follower could see them is if Leader pushed them to DB.
-        // But the comment says "We do NOT push Global Stats".
-        //
-        // So checking "should return aggregated metrics (including external Global Stats)" might be invalid expectation
-        // based on current implementation if Global Stats are not persisted.
-        //
-        // Let's verify this behavior.
-        // Expectation: Follower in Cluster Mode returns Aggregated Local Metrics, but NO Queue Depth.
 
         const registry = await instance.mongodash.getPrometheusMetrics();
         const json = await registry!.getMetricsAsJSON();
 
-        // Should NOT have Queue Depth (because we are Follower and we don't compute it, and it's not in DB)
-        expect(find(json, { name: 'reactive_tasks_queue_depth' })).toBeUndefined();
+        // Queue depth was pushed by the (pre-stub) leader; follower
+        // now reads it from the DB registry doc.
+        expect(find(json, { name: 'reactive_tasks_queue_depth' })).toBeDefined();
+        expect(find(json, { name: 'reactive_tasks_global_lag_seconds' })).toBeDefined();
 
-        // Should have Local metrics
+        // Local metrics still present.
         expect(find(json, { name: 'reactive_tasks_duration_seconds' })).toBeDefined();
 
         await instance.mongodash.stopReactiveTasks();

--- a/test/reactiveTasks/monitoring.test.ts
+++ b/test/reactiveTasks/monitoring.test.ts
@@ -826,7 +826,8 @@ describe('Reactive Task Monitoring', () => {
 
         // Follower should now include Global Stats too: the leader pushes them
         // to the registry doc on each interval, and the follower reads them
-        // there. Freshness is bounded by pushIntervalMs (100 in this test).
+        // there. Freshness is bounded by GLOBAL_STATS_STALE_MULTIPLIER *
+        // pushIntervalMs (2 * 100ms = 200ms in this test).
         expect(find(followerJson, { name: 'reactive_tasks_queue_depth' })).toBeDefined();
         expect(find(followerJson, { name: 'reactive_tasks_global_lag_seconds' })).toBeDefined();
 

--- a/test/reactiveTasks/monitoring.test.ts
+++ b/test/reactiveTasks/monitoring.test.ts
@@ -3,7 +3,7 @@ import { find, noop, some } from 'lodash';
 import { Document } from 'mongodb';
 import * as sinon from 'sinon';
 import { createSandbox } from 'sinon';
-import { createReusableWaitableStub, getNewInstance, wait } from '../testHelpers';
+import { createReusableWaitableStub, getNewInstance, wait, waitUntil } from '../testHelpers';
 import { assertMetricValue, getMetric, getMetricValue, GlobalsRegistryDoc } from '../testHelpersReactive';
 
 const debug = _debug('mongodash:reactiveTasks:monitoring:test');
@@ -885,9 +885,17 @@ describe('Reactive Task Monitoring', () => {
         });
 
         await instance.mongodash.startReactiveTasks();
-        // Wait long enough for election + a push cycle so globalStats
-        // lands in the registry doc.
-        await wait(500);
+
+        // Poll the registry doc for the leader's pushed globalStats rather
+        // than relying on a fixed sleep (flaky on slow CI).
+        const globalsCollection = instance.mongodash.getCollection<GlobalsRegistryDoc>(GLOBAL_COLLECTION_NAME);
+        await waitUntil(
+            async () => {
+                const doc = await globalsCollection.findOne({ _id: 'reactive_tasks_metrics_registry' });
+                return !!doc?.globalStats;
+            },
+            { timeoutMs: 5000, message: 'leader pushed globalStats to the registry doc' },
+        );
 
         const scheduler = (instance.mongodash as any)._scheduler;
         sinon.stub(scheduler.leaderElector, 'isLeader').get(() => false);

--- a/test/testHelpersReactive.ts
+++ b/test/testHelpersReactive.ts
@@ -7,11 +7,15 @@ import { MetricObjectWithValues, MetricValue } from 'prom-client';
  */
 export interface GlobalsRegistryDoc extends Document {
     _id: string;
-    instances: Record<string, any>;
+    instances: Array<{
+        id: string;
+        lastSeen: Date | string;
+        metrics: MetricObjectWithValues<MetricValue<string>>[];
+    }>;
     globalStats?: {
         updatedAt: Date | string;
         leaderId: string;
-        metrics: unknown;
+        metrics: MetricObjectWithValues<MetricValue<string>>[];
     };
 }
 

--- a/test/testHelpersReactive.ts
+++ b/test/testHelpersReactive.ts
@@ -8,6 +8,11 @@ import { MetricObjectWithValues, MetricValue } from 'prom-client';
 export interface GlobalsRegistryDoc extends Document {
     _id: string;
     instances: Record<string, any>;
+    globalStats?: {
+        updatedAt: Date | string;
+        leaderId: string;
+        metrics: unknown;
+    };
 }
 
 /**


### PR DESCRIPTION
Three related scheduler / observability improvements, each standalone.

## 1. Cron: unify serial and parallel scheduler (1362929)

`cronTaskConcurrency === 1` used its own setTimeout-driven loop; only
`>1` used `ConcurrentRunner`. The duality existed because the pre-PR-#463
test suite was byte-for-byte coupled to the serial loop's timing. With
the behaviour-level + regression split from #463 the reason is gone.

- Always instantiates `state.runner` in init().
- Deletes `runATask` serial loop and `working` / `pendingWake` /
  `nextTaskTimeoutId` state fields.
- `ensureStarted` + `stopCronTasks` have only the runner path.

Net: `src/cronTasks.ts` -79 LOC, behaviour unchanged for
`cronTaskConcurrency === 1` users.

## 2. ConcurrentRunner: close two scheduler races (96a9558 + 75f8322)

Unification surfaced two races:

- **Stale nextRunAt across stop/start**: `ConcurrentRunner` preserves
  source metadata across `stop()` for re-use. A previous cycle's
  `nextRunAt = prolongNextRun()` would make a freshly spawned worker
  sleep the remainder of that window before noticing new work. `start()`
  now resets each source's nextRunAt + currentBackoff.
- **setNextRunAt swallowing a concurrent speedUp**: a worker's
  post-poll `setNextRunAt(now + waitMs)` based on a stale filter could
  overwrite a `speedUp()` that fired during the worker's DB round-trip.
  `setNextRunAt` now no-ops when `nextRunAt` is already `<= now` -
  something more urgent has signalled an immediate poll.

Both behaviours are covered by regression tests in
`test/ConcurrentRunner.ts` that fail at commit `1362929` (pre-fix) and
pass on HEAD.

## 3. reactive-tasks metrics: follower scrapes now return global stats (46407b4)

Public docs (`docs/reactive-tasks/monitoring.md`) promise that in
`cluster` scrape mode "any instance can respond to this request" -
but the implementation computed global stats (queue_depth, global_lag,
last_reconciliation, change_stream_lag) only on the Leader. Any scrape
that landed on a Follower returned an incomplete view. Production
observed these four gauges "sometimes missing" in Prometheus.

Fix: the Leader bundles its freshly computed global stats into a new
`globalStats` singleton field on the registry document on each push.
Followers read that field on scrape. Single-writer pattern prevents
double-counting across leader transitions; freshness is bounded by
`pushIntervalMs`.

## Test plan

- [x] `test/cronTasks.{scheduling,behavior,parallel,races.regression}.ts` — 73 green
- [x] `test/ConcurrentRunner.ts` — 14 green (3 new)
- [x] `test/reactiveTasks/**` — 246 green (2 monitoring tests flipped to assert the fixed behaviour)
- [x] `npm run test:lint` clean
- [x] `npm run test:ts` clean
- [x] `npm run test:simple` parallel: 333 green across 41 suites (~35s on 10 workers, 68s on 4)
- [ ] CI
- [ ] Copilot review rounds